### PR TITLE
Update switch_grid.sh to work with new wew

### DIFF
--- a/switch_grid.sh
+++ b/switch_grid.sh
@@ -79,7 +79,7 @@ done
 # END Z3BRA
 
 # listen to wew for our desired event
-wew | while IFS=: read ev wid; do
+wew -m 4 | while IFS=: read ev wid; do
     if [ $ev -eq 4 ]; then
         while read line; do
             wtp $line


### PR DESCRIPTION
With the new `wew` detecting clicks is disabled by default.  You need to use mask num 4, e.g. `wew -m 4`. This makes that update.
