### PR TITLE
Properly avoid modifying a fullscreen window's border

### DIFF
--- a/focus.sh
+++ b/focus.sh
@@ -22,7 +22,12 @@ setborder() {
     wattr $2 || return
 
     # do not modify border of fullscreen windows
-    test "$(wattr xywh $2)" = "$(wattr xywh $ROOT)" && return
+    if [ -f $HOME/.fwin ]; then
+        wid=cat $HOME/.fwin | grep $2
+        if [ $wid = $2 ]; then
+            return
+        fi
+    fi
 
     case $1 in
         active)   chwb -s $BW -c $ACTIVE $2 ;;


### PR DESCRIPTION
Previously the script performed a test that would always render a false-positive on windows that had a border applied by the focus script prior to triggering the fullscreen.sh script, because the borders would cause the xy resolution compared to the root window to be off by the size of the original border.  

This commit instead checks for the presence of $HOME/.fwin which is set by the fullscreen.sh script and then performs a comparison on the wid contained in that file. The result is the desired behavior of not modifying the border of the fullscreen window (the border is actually removed and not re-set to whichever value it would have when not in fullscreen).
