### PR TITLE
Add: deletelock.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Depends on `wew(1)` (opt repo)  and `focus.sh` (contrib repo)
 
     usage: switch_grid.sh
 
+### deletelock.sh
+Set a custom xprop variable which can be used to test if a window is able to
+be deleted or not when using killw in a custom script with `wew(1)`.
+
+Depends on xorg-xprop
+
+    usage: deletelock.sh <lock|unlock|toggle|status> <wid>
+
 ### groups.sh
 Adds group-like capabilities, sorta like those you find in CWM and such WMs.
 

--- a/deletelock.sh
+++ b/deletelock.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# wildefyr - 2015 (c) wtfpl
+# toggle delete lock for current window
+
+usage() {
+    echo "usage: $(basename $0) <lock|unlock|toggle|status> <wid>"
+    exit 1
+}
+
+wid=$(pfw)
+
+case $2 in
+    0x*)
+        wid=$2
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+case $1 in
+    lock)
+        xprop -id $wid -f _WMUTILS_DELETELOCK 8i -set _WMUTILS_DELETELOCK '1'
+        ;;
+    unlock)
+        xprop -id $wid -remove _WMUTILS_DELETELOCK
+        ;;
+    toggle)
+        lockStatus=$(xprop -id $wid _WMUTILS_DELETELOCK | cut -d\  -f 3)
+        case $lockStatus in
+            1)
+                $(basename $0) unlock $wid 
+                ;;
+            *)
+                $(basename $0) lock $wid 
+                ;;
+        esac
+        ;;
+    status)
+        lockStatus=$(xprop -id $wid _WMUTILS_DELETELOCK | cut -d\  -f 3)
+        case $lockStatus in
+            1)
+                echo "1"
+                ;;
+            *)
+                echo "0"
+                ;;
+        esac
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
Tool for changing the status of windows mortality. Can be used in combination with a winopen.sh and/or killw to disallow a window being killed by that method. This does not cover self-termination/kill -9 integration, although I think the latter could be done with care if needed.

Also gives a decent example on how to manipulate xprop window settings and how it can be integrated with wmutils, which is useful if you want a window to maintain information later. Although it is an 'external' dependency to wmutils, I believe it is acceptable in this use case as it's window related data and xprop is a very handy tool for scraping all sorts of data to the user which wmutils does not provide. 
