### PR TITLE
Correcting border issues

### DIFF
--- a/focus.sh
+++ b/focus.sh
@@ -24,13 +24,12 @@ setborder() {
     test "$(wattr xywh $2)" = "$(wattr xywh $ROOT)" && return
 
     case $1 in
-        active)   chwb -c $ACTIVE $2
-                  if [ -n $BW ]; then chwb -s $BW $2; fi
-                  ;;
-        inactive) chwb -c $INACTIVE $2
-                  if [ -n $BW ]; then chwb -s $BW $2; fi
-                  ;;
+        active)   chwb -c $ACTIVE $2;;
+        inactive) chwb -c $INACTIVE $2;;
     esac
+    
+    #change border width only if $BW is set
+    if [ -n $BW ]; then chwb -s $BW $2; fi
 }
 
 case $1 in

--- a/focus.sh
+++ b/focus.sh
@@ -3,7 +3,6 @@
 # z3bra - 2014 (c) wtfpl
 # window focus wrapper that sets borders and can focus next/previous window
 
-BW=${BW:-2}                    # border width
 ACTIVE=${ACTIVE:-0xffffff}     # active border color
 INACTIVE=${INACTIVE:-0x333333} # inactive border color
 
@@ -25,8 +24,8 @@ setborder() {
     test "$(wattr xywh $2)" = "$(wattr xywh $ROOT)" && return
 
     case $1 in
-        active)   chwb -s $BW -c $ACTIVE $2 ;;
-        inactive) chwb -s $BW -c $INACTIVE $2 ;;
+        active)   chwb -c $ACTIVE $2 ;;
+        inactive) chwb -c $INACTIVE $2 ;;
     esac
 }
 

--- a/focus.sh
+++ b/focus.sh
@@ -24,8 +24,12 @@ setborder() {
     test "$(wattr xywh $2)" = "$(wattr xywh $ROOT)" && return
 
     case $1 in
-        active)   chwb -c $ACTIVE $2 ;;
-        inactive) chwb -c $INACTIVE $2 ;;
+        active)   chwb -c $ACTIVE $2
+                  if [ -n $BW ]; then chwb -s $BW $2; fi
+                  ;;
+        inactive) chwb -c $INACTIVE $2
+                  if [ -n $BW ]; then chwb -s $BW $2; fi
+                  ;;
     esac
 }
 

--- a/fullscreen.sh
+++ b/fullscreen.sh
@@ -19,7 +19,7 @@ test -z "$1" && usage
 # this will unset the fullscreen state of any fullscreen window if there is one.
 # this way, there will only be one window in fullscreen at a time, and no window
 # will loose their previous geometry info
-test -f $FSFILE && wtp $(cat $FSFILE)
+test -f $FSFILE && wtp $(head -n1 $FSFILE) && chwb -s $(tail -n1 $FSFILE) 
 
 # if file exist and contain our window id, it means that out window is in
 # fullscreen mode
@@ -32,6 +32,7 @@ else
     # if not, then put the current window in fullscreen mode, after saving its
     # geometry and id to $FSFILE we also remove any border from this window.
     wattr xywhi $1 > $FSFILE
+    echo -e "$(cat $FSFILE)\n$(wattr b $(pfw)) $(pfw)" > $FSFILE
     wtp $(wattr xywh `lsw -r`) $1
     chwb -s 0 $1
 fi

--- a/fullscreen.sh
+++ b/fullscreen.sh
@@ -33,6 +33,7 @@ else
     # geometry, border, and id to $FSFILE we also remove any border from this window.
     wattr xywhi $1 > $FSFILE
     echo -e "$(cat $FSFILE)\n$(wattr b $(pfw)) $(pfw)" > $FSFILE
+    
     wtp $(wattr xywh `lsw -r`) $1
     chwb -s 0 $1
 fi

--- a/fullscreen.sh
+++ b/fullscreen.sh
@@ -30,7 +30,7 @@ if test -f $FSFILE && grep -q $1 $FSFILE; then
 
 else
     # if not, then put the current window in fullscreen mode, after saving its
-    # geometry and id to $FSFILE we also remove any border from this window.
+    # geometry, border, and id to $FSFILE we also remove any border from this window.
     wattr xywhi $1 > $FSFILE
     echo -e "$(cat $FSFILE)\n$(wattr b $(pfw)) $(pfw)" > $FSFILE
     wtp $(wattr xywh `lsw -r`) $1


### PR DESCRIPTION
The main issue is that focus.sh automatically changes a window's border width to two if $BW is unset. Because fullscreen.sh relies on focus.sh to set window border (and focus the window), the same thing happens to fullscreened windows that are restored using fullscreen.sh.

The changes are:
1) fullscreen.sh now stores border data along with the information it had previously stored in the same file. Un-fullscreening a window will now apply its previous border size, in addition to the proper size and position.

2) focus.sh now will only set/change border width if $BW is set. This means that if you are a dumb user like me, neglecting to set $BW will simply result in a window keeping its previous border size. Basically, it increases the chance that focus.sh will not do the wrong thing.
