### PR TITLE
Add: adjust.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Adds group-like capabilities, sorta like those you find in CWM and such WMs.
            -u unmaps (hides) group
            -U unmaps all the groups
 
-### wmnenu.sh
+### wmenu.sh
 
 Uses wname and dmenu to produce a window selection menu similar to CWM's
 menu-window option. Upon selection the script outputs the chosen window id that

--- a/README.md
+++ b/README.md
@@ -35,13 +35,24 @@ environment.
 
     usage: rainbow.sh
 
+### adjust.sh
+
+Move the current or given window id in a direction.
+
+    Usage:
+        $ $base up    | --up)    Move $JUMP pixels up.
+        $ $base down  | --down)  Move $JUMP pixels down.
+        $ $base left  | --left)  Move $JUMP pixels left.
+        $ $base right | --right) Move $JUMP pixels right.
+
+
 ### closest.sh
 Focus the closest window in a specific direction.
 
     usage: closest.sh <direction>
 
 ### underneath.sh
-Produce window id directely underneath cursor.
+Produce window id directly underneath cursor.
 
 Example sxhkd binding:
 

--- a/adjust.sh
+++ b/adjust.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# fyr | 2019 (c) MIT
+# wrapper around wmv to adjust window position
+
+usage() {
+    base="$(basename $0)"
+    cat >&2 << EOF
+Usage:
+    $ $base up    | --up)    Move $JUMP pixels up.
+    $ $base down  | --down)  Move $JUMP pixels down.
+    $ $base left  | --left)  Move $JUMP pixels left.
+    $ $base right | --right) Move $JUMP pixels right.
+EOF
+
+    test $# -eq 0 || exit $1
+}
+
+main() {
+    JUMP=20
+
+    case $# in
+        1) wid="$(pfw)"              ;;
+        2) widCheck "$2" && wid="$2" ;;
+    esac
+
+    case "$1" in
+        up|--up)        wmv 0 -$JUMP $wid ;;
+        down|--down)    wmv 0 +$JUMP $wid ;;
+        left|--left)    wmv -$JUMP 0 $wid ;;
+        right|--right)  wmv +$JUMP 0 $wid ;;
+        -h|--help|help) usage 0           ;;
+        *)              usage 1           ;;
+    esac
+
+    # move mouse to middle of window
+    # wmp -a $(($(wattr x $wid) + $(wattr w $wid) / 2)) \
+    #        $(($(wattr y $wid) + $(wattr h $wid) / 2))
+}
+
+main "$@"


### PR DESCRIPTION
Never realised there was no example of how to use `wmv`. I myself completely forgot about wmv until recently, probably because it is overshadowed by the other great tools in core. I've left commented out how to move the mouse pointer central to window if people are interested in that usage with other tools like CWM. Also included are a couple of typos in the readme.

I'd like to modify wmv in the future to work using xrandr to detect the monitor edges instead of purely relying on the size of the root window to know where to stop the window. @z3bra would this be out of scope for core? considering core would then be relying on another library. However, I'm struggling to think of a time where it's not installed alongside other xorg packages.