### PR TITLE
removed -name flag on dmenu call in wmenu.sh

### DIFF
--- a/wmenu.sh
+++ b/wmenu.sh
@@ -9,6 +9,6 @@ LINES=$(lsw | wc -l)
 wid=$(\
     for wid in $(lsw); do
         printf '%s\n' "$wid | $(wname $wid)"
-    done | dmenu -name "wmenu" -l $LINES -p "Window:" | cut -d\  -f 1)
+    done | dmenu -l $LINES -p "Window:" | cut -d\  -f 1)
 
 test -n "$wid" && focus.sh "$wid"


### PR DESCRIPTION
minor edit: the `-name` flag has been deprecated/disabled from dmenu, hence modified `wmenu.sh` accordingly